### PR TITLE
Build the app with Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+watch_file default.nix treefmt.nix
+use flake

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,18 @@
+name: Run checks
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  checks:
+    name: Nix checks
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-24.11
+      - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/result
+/.direnv

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
   gobject-introspection,
   writeText,
   wrapGAppsHook,
+  makeWrapper
 }:
 let
   pygobject-stubs' = python3Packages.pygobject-stubs.overridePythonAttrs (old: {
@@ -32,6 +33,7 @@ python3Packages.buildPythonPackage {
     ruff
     gobject-introspection
     wrapGAppsHook
+    makeWrapper
   ];
   src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,51 @@
+{
+  runCommand,
+  ruff,
+  dmenu,
+  python3,
+  python3Packages,
+  networkmanager,
+  gobject-introspection,
+  writeText,
+  wrapGAppsHook,
+}:
+let
+  pygobject-stubs' = python3Packages.pygobject-stubs.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ ([
+      networkmanager
+      python3Packages.pygobject3
+    ]);
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ gobject-introspection ];
+    # see https://github.com/pygobject/pygobject-stubs/pull/204
+    patches = (old.patches or [ ]) ++ [ ./pygobject.patch ];
+    postPatch = ''
+      python tools/generate.py NM 1.0 > src/gi-stubs/repository/NM.pyi
+    '';
+  });
+
+in
+python3Packages.buildPythonPackage {
+  name = "network_manager_ui";
+  nativeBuildInputs = [
+    pygobject-stubs'
+    python3Packages.mypy
+    ruff
+    gobject-introspection
+    wrapGAppsHook
+  ];
+  src = ./.;
+
+  buildInputs = [
+    networkmanager
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    dmenu
+    pygobject3
+  ];
+
+  checkPhase = ''
+    python -m mypy network_manager_ui.py
+    ruff check network_manager_ui.py
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740162160,
+        "narHash": "sha256-SSYxFhqCOb3aiPb6MmN68yEzBIltfom8IgRz7phHscM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "11415c7ae8539d6292f2928317ee7a8410b28bb9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1735554305,
+        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,6 @@
           checks.builds = network_manager_ui;
         }
       )) // {
-        hmModules.default = ./hmModule.nix self;
+        homeModules.default = import ./hmModule.nix self;
       };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      treefmt-nix,
+      self,
+    }:
+    flake-utils.lib.eachSystem
+      (with flake-utils.lib.system; [
+        x86_64-linux
+        aarch64-linux
+      ])
+      (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+          network_manager_ui = pkgs.callPackage ./default.nix { };
+        in
+        {
+          devShells.default = network_manager_ui.inputDerivation;
+          packages.network_manager_ui = network_manager_ui;
+          formatter = treefmtEval.config.build.wrapper;
+          checks.formatting = treefmtEval.config.build.check self;
+          checks.builds = network_manager_ui;
+        }
+      );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       treefmt-nix,
       self,
     }:
-    flake-utils.lib.eachSystem
+    (flake-utils.lib.eachSystem
       (with flake-utils.lib.system; [
         x86_64-linux
         aarch64-linux
@@ -29,5 +29,7 @@
           checks.formatting = treefmtEval.config.build.check self;
           checks.builds = network_manager_ui;
         }
-      );
+      )) // {
+        hmModules.default = ./hmModule.nix self;
+      };
 }

--- a/hmModule.nix
+++ b/hmModule.nix
@@ -1,0 +1,65 @@
+flake:
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    all filterAttrs hasAttr isStorePath literalExpression optional optionalAttrs
+    types;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+
+  cfg = config.programs.network_manager_ui;
+in {
+    options.programs.network_manager_ui = {
+        enable = mkEnableOption "network_manager_ui";
+
+        dmenu = {
+            pinentry = mkOption {
+                type = types.package;
+                example = literalExpression "pkgs.pinentry-gtk";
+                default = pkgs.pinentry-gtk;
+                description = ''
+                    Which pinentry interface to use.
+                '';
+                # we want the program in the config
+                apply = val: if val == null then val else lib.getExe val;
+            };
+        };
+
+        pinentry.prompt = mkOption {
+            type = text;
+            default = "Password:";
+            description = "Pinentry prompt"; 
+        };
+
+        editor.terminal = mkOption {
+            type = types.str;
+            default = "${pkgs.kitty}/bin/kitty";
+            description = "Default terminal to run.";
+            example = "alacritty";
+        };
+    };
+
+    config = lib.mkIf cfg.enable {
+        xdg.configFile.networkmanager."config.ini".text = pkgs.lib.generators.toINI {} {
+            dmenu = {
+                dmenu_command = "rofi -dmenu -theme ${./wifi} -i -no-history -matching fuzzy -no-tokenize -hover-select";
+
+                pinentry = cfg.dmenu.pinentry;
+                wifi_icons = "󰤯󰤟󰤢󰤥󰤨";
+                format = "{name} {icon}";
+                list_saved = "False";
+            };
+
+            pinentry = {
+                prompt = cfg.pinentry.prompt;
+            };
+
+            editor = {
+                terminal = cfg.editor.terminal;
+            };
+        };
+
+        home.packages = [ flake.packages.${pkgs.stdenv.system}.network_manager_ui ];
+    };
+}

--- a/hmModule.nix
+++ b/hmModule.nix
@@ -13,21 +13,31 @@ in {
     options.programs.network_manager_ui = {
         enable = mkEnableOption "network_manager_ui";
 
+        rofiPkg = mkOption {
+            type = types.package;
+            example = literalExpression "pkgs.wofi";
+            default = pkgs.rofi;
+            description = ''
+            Which 'rofi' to use e.g. rofi, rofi-wayland
+            '';
+            apply = val: lib.getExe val;
+        };
+
         dmenu = {
             pinentry = mkOption {
                 type = types.package;
-                example = literalExpression "pkgs.pinentry-gtk";
-                default = pkgs.pinentry-gtk;
+                example = literalExpression "pkgs.pinentry-rofi";
+                default = pkgs.pinentry-rofi;
                 description = ''
                     Which pinentry interface to use.
                 '';
                 # we want the program in the config
-                apply = val: if val == null then val else lib.getExe val;
+                apply = val: lib.getExe val;
             };
         };
 
         pinentry.prompt = mkOption {
-            type = text;
+            type = types.str;
             default = "Password:";
             description = "Pinentry prompt"; 
         };
@@ -41,9 +51,9 @@ in {
     };
 
     config = lib.mkIf cfg.enable {
-        xdg.configFile.networkmanager."config.ini".text = pkgs.lib.generators.toINI {} {
+        xdg.configFile."networkmanager/config.ini".text = pkgs.lib.generators.toINI {} {
             dmenu = {
-                dmenu_command = "rofi -dmenu -theme ${./wifi} -i -no-history -matching fuzzy -no-tokenize -hover-select";
+                dmenu_command = "${cfg.rofiPkg} -dmenu -theme ${./wifi}/config.rasi -i -no-history -matching fuzzy -no-tokenize -hover-select";
 
                 pinentry = cfg.dmenu.pinentry;
                 wifi_icons = "󰤯󰤟󰤢󰤥󰤨";

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ fi
 
 # Move network_manager script to /usr/local/bin/
 echo -e "\033[1;34mMoving network_manager to /usr/local/bin/\033[0m"
-sudo cp network_manager /usr/local/bin/
+sudo cp network_manager_ui.py /usr/local/bin/network_manager
 if [ $? -eq 0 ]; then
     echo -e "\033[1;32mSuccess: network_manager moved to /usr/local/bin/\033[0m"
 else

--- a/network_manager_ui.py
+++ b/network_manager_ui.py
@@ -25,11 +25,9 @@ from time import sleep
 import uuid
 import subprocess
 
-# pylint: disable=import-error
 import gi
 gi.require_version('NM', '1.0')
 from gi.repository import GLib, NM  # noqa pylint: disable=wrong-import-position
-# pylint: enable=import-error
 
 ENV = os.environ.copy()
 ENC = locale.getpreferredencoding()
@@ -221,7 +219,7 @@ def rescan_wifi():
     """
     delay = CONF.getint('nmdm', 'rescan_delay', fallback=5)
     for dev in CLIENT.get_devices():
-        if gi.repository.NM.DeviceWifi == type(dev):
+        if isinstance(dev, gi.repository.NM.DeviceWifi):
             try:
                 dev.request_scan_async(None, rescan_cb, None)
                 LOOP.run()

--- a/pygobject.patch
+++ b/pygobject.patch
@@ -1,0 +1,59 @@
+From fa3231a1a6b0ca807de3e2683b7c44dd23e88899 Mon Sep 17 00:00:00 2001
+From: James Baker <j.baker@outlook.com>
+Date: Sun, 23 Feb 2025 12:13:25 +0000
+Subject: [PATCH] fixes in order to support NetworkManager
+
+I wanted to generate stubs using this tool for NetworkManager (NM).
+
+What I found was failures for two reasons:
+
+1. Cannot generate due to invalid identifiers (80211Flags).
+1. Some enums with no entries.
+
+I fixed this by:
+
+1. Quoting those identifiers. My belief is that this will keep mypy
+   working but fixing the python level issues.
+1. Printing `pass` after each enum with empty entries.
+---
+ tools/generate.py | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/tools/generate.py b/tools/generate.py
+index 4fdfdcb..0eb4039 100755
+--- a/tools/generate.py
++++ b/tools/generate.py
+@@ -313,7 +313,11 @@ def _type_to_python(
+                 return f"typing.Callable[[{', '.join(args)}], {return_type}]"
+         else:
+             namespace = interface.get_namespace()
+-            name = interface.get_name()
++            raw_name = interface.get_name()
++            if raw_name[0].isdigit():
++                name = f'"{raw_name}"'
++            else:
++                name = raw_name
+ 
+             if namespace == "GObject" and name == "Value":
+                 return "typing.Any"
+@@ -885,6 +889,7 @@ def _gi_build_stub(
+             base = "GObject.GEnum"
+ 
+         ret += f"class {name}({base}):\n"
++        any_variants = False
+         for key in sorted(vars(obj)):
+             if key.startswith("__") or key[0].isdigit():
+                 continue
+@@ -907,6 +912,9 @@ def _gi_build_stub(
+                 ret += f"    {key} = {value}\n"
+             else:
+                 ret += f"    {key} = ... # FIXME Enum\n"
++            any_variants = True
++        if not any_variants:
++            ret += "    pass\n"
+         ret += "\n"
+ 
+     return ret
+-- 
+2.47.2
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name="network_manager_ui",
+    version="0.0.0",
+    py_modules=["network_manager_ui"],
+    entry_points = {
+        'console_scripts': [
+            "network_manager_ui = network_manager_ui:main"
+        ]
+    }
+)

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  projectRootFile = "flake.nix";
+  programs.nixfmt.enable = true;
+  programs.ruff.enable = true;
+}

--- a/wifi/config.rasi
+++ b/wifi/config.rasi
@@ -1,4 +1,4 @@
-@theme "~/.config/rofi/wifi/themes/rosepine.rasi"
-	conordnfiguration {
+@theme "./themes/rosepine.rasi"
+	configuration {
 	terminal: "kitty";
 	}


### PR DESCRIPTION
This is an MVP integration of this app with NixOS.

It:

1. Builds the python code with Nix into an application with no further dependencies. Lint with ruff and mypy.
2. Adds a default formatter.
3. Adds CI.
4. Defines a home module which references config files in the right places.

To get decent type stubs for networkmanager, I rebuild pygobject-stubs with the extra NM section.

It's not yet perfect; it needs to expose slightly more configurability to the user. However, it certainly is at the point of being usable, at least for me.